### PR TITLE
Add const to the payload so can pass in a const uint8_t* instead of having to cast it

### DIFF
--- a/src/LoraMesher.h
+++ b/src/LoraMesher.h
@@ -250,7 +250,7 @@ public:
      * @param payload Payload to send
      * @param payloadSize Payload size to be send in Bytes
      */
-    void sendPacket(uint16_t dst, uint8_t* payload, uint32_t payloadSize) {
+    void sendPacket(uint16_t dst, const uint8_t* payload, uint32_t payloadSize) {
         //Cannot send an empty packet
         if (payloadSize == 0)
             return;

--- a/src/services/PacketFactory.h
+++ b/src/services/PacketFactory.h
@@ -28,7 +28,7 @@ public:
      * @return T* Pointer to the newly created packet, or nullptr if allocation failed
      */
     template <typename T>
-    static T* createPacket(uint8_t* payload, uint8_t payloadSize) {
+    static T* createPacket(const uint8_t* payload, uint8_t payloadSize) {
         // Calculate the total packet size (header + payload)
         const size_t headerSize = sizeof(T);
         const size_t requestedPacketSize = headerSize + payloadSize;

--- a/src/services/PacketService.cpp
+++ b/src/services/PacketService.cpp
@@ -136,7 +136,7 @@ ControlPacket* PacketService::createEmptyControlPacket(uint16_t dst, uint16_t sr
     return packet;
 }
 
-DataPacket* PacketService::createDataPacket(uint16_t dst, uint16_t src, uint8_t type, uint8_t* payload, uint8_t payloadSize) {
+DataPacket* PacketService::createDataPacket(uint16_t dst, uint16_t src, uint8_t type, const uint8_t* payload, uint8_t payloadSize) {
     DataPacket* packet = PacketFactory::createPacket<DataPacket>(payload, payloadSize);
     packet->dst = dst;
     packet->src = src;

--- a/src/services/PacketService.h
+++ b/src/services/PacketService.h
@@ -63,7 +63,7 @@ public:
      * @param payloadSize Payload size
      * @return DataPacket*
      */
-    static DataPacket* createDataPacket(uint16_t dst, uint16_t src, uint8_t type, uint8_t* payload, uint8_t payloadSize);
+    static DataPacket* createDataPacket(uint16_t dst, uint16_t src, uint8_t type, uint8_t* payload, const uint8_t payloadSize);
 
     /**
      * @brief Create an Empty Packet

--- a/src/services/PacketService.h
+++ b/src/services/PacketService.h
@@ -63,7 +63,7 @@ public:
      * @param payloadSize Payload size
      * @return DataPacket*
      */
-    static DataPacket* createDataPacket(uint16_t dst, uint16_t src, uint8_t type, uint8_t* payload, const uint8_t payloadSize);
+    static DataPacket* createDataPacket(uint16_t dst, uint16_t src, uint8_t type, const uint8_t* payload,  uint8_t payloadSize);
 
     /**
      * @brief Create an Empty Packet


### PR DESCRIPTION
The sendMessage library doesn't actually change things, but its declarations don't use "const" as liberally as could 

Most places it doesn't matter - but this fixes the problem of not being able to pass a const uint8_t* as a payload