### PR TITLE
fix(routing): guard against hop_count overflow in ProcessRoutingTableMessage

### DIFF
--- a/src/protocols/lora_mesh/routing/distance_vector_routing_table.cpp
+++ b/src/protocols/lora_mesh/routing/distance_vector_routing_table.cpp
@@ -838,6 +838,13 @@ bool DistanceVectorRoutingTable::ProcessRoutingTableMessage(
             continue;
         }
 
+        // Reject entries whose hop count would overflow uint8_t on the +1
+        // below; without this check the wraparound could produce a hop
+        // count smaller than max_hops and bypass the filtering entirely.
+        if (entry.hop_count >= 255) {
+            continue;
+        }
+
         // Calculate actual metrics through source
         uint8_t hop_count_via_source = entry.hop_count + 1;
         uint8_t actual_link_quality =

--- a/src/protocols/lora_mesh/routing/distance_vector_routing_table.cpp
+++ b/src/protocols/lora_mesh/routing/distance_vector_routing_table.cpp
@@ -838,9 +838,6 @@ bool DistanceVectorRoutingTable::ProcessRoutingTableMessage(
             continue;
         }
 
-        // Reject entries whose hop count would overflow uint8_t on the +1
-        // below; without this check the wraparound could produce a hop
-        // count smaller than max_hops and bypass the filtering entirely.
         if (entry.hop_count >= 255) {
             continue;
         }

--- a/test/protocols/lora_mesh/services/test_routing_unit/routing_table_unit_test.cpp
+++ b/test/protocols/lora_mesh/services/test_routing_unit/routing_table_unit_test.cpp
@@ -307,8 +307,6 @@ TEST_F(RoutingTableUnitTest, ProcessRoutingMessageRespectsMaxHops) {
 }
 
 TEST_F(RoutingTableUnitTest, ProcessRoutingMessageRejectsHopCountOverflow) {
-    // A wire-supplied hop_count of 255 would wrap to 0 when incremented by
-    // one for the local hop, which must not bypass the max_hops filter.
     auto table = DistanceVectorRoutingTable(kLocalAddress);
 
     std::vector<RoutingTableEntry> entries;
@@ -317,9 +315,7 @@ TEST_F(RoutingTableUnitTest, ProcessRoutingMessageRejectsHopCountOverflow) {
     table.ProcessRoutingTableMessage(kNeighbor1, entries, kCurrentTime,
                                      kGoodQuality, 5);  // max_hops = 5
 
-    // Remote node must NOT be added despite the arithmetic wraparound.
     EXPECT_FALSE(table.IsNodePresent(kRemoteNode));
-    // But source should still be added as direct neighbor.
     EXPECT_TRUE(table.IsNodePresent(kNeighbor1));
 }
 

--- a/test/protocols/lora_mesh/services/test_routing_unit/routing_table_unit_test.cpp
+++ b/test/protocols/lora_mesh/services/test_routing_unit/routing_table_unit_test.cpp
@@ -306,6 +306,23 @@ TEST_F(RoutingTableUnitTest, ProcessRoutingMessageRespectsMaxHops) {
     EXPECT_TRUE(table.IsNodePresent(kNeighbor1));
 }
 
+TEST_F(RoutingTableUnitTest, ProcessRoutingMessageRejectsHopCountOverflow) {
+    // A wire-supplied hop_count of 255 would wrap to 0 when incremented by
+    // one for the local hop, which must not bypass the max_hops filter.
+    auto table = DistanceVectorRoutingTable(kLocalAddress);
+
+    std::vector<RoutingTableEntry> entries;
+    entries.push_back(CreateEntry(kRemoteNode, 255, kGoodQuality));
+
+    table.ProcessRoutingTableMessage(kNeighbor1, entries, kCurrentTime,
+                                     kGoodQuality, 5);  // max_hops = 5
+
+    // Remote node must NOT be added despite the arithmetic wraparound.
+    EXPECT_FALSE(table.IsNodePresent(kRemoteNode));
+    // But source should still be added as direct neighbor.
+    EXPECT_TRUE(table.IsNodePresent(kNeighbor1));
+}
+
 // =============================================================================
 // Full Mesh Topology Tests (simulating the failing integration test)
 // =============================================================================


### PR DESCRIPTION
## Problem

`entry.hop_count` in `DistanceVectorRoutingTable::ProcessRoutingTableMessage()` is a `uint8_t` read directly from the wire-format routing table entry (`RoutingTableEntry::Deserialize()` only checks that the byte was present, it never range-checks the value). The function computes:

```cpp
uint8_t hop_count_via_source = entry.hop_count + 1;
...
if (hop_count_via_source > max_hops) {
    continue;
}
```

If a peer (malicious, buggy, or corrupted) sends `entry.hop_count = 255`, the `+ 1` wraps around to `0`, so `hop_count_via_source` becomes `0`, which is never greater than `max_hops`. The entry is admitted instead of rejected.

Because `NetworkNodeRoute::CalculateRouteCost()` computes `cost = hop_count * 65536 / quality`, a wrapped `hop_count = 0` always yields the minimum possible cost, so `IsBetterRoute()` will prefer this phantom "0-hop" route over any legitimate route with `hop_count >= 1` — effectively letting a single malformed/malicious routing-table entry hijack the forwarding path for a destination.

The sibling function `UpdateRoute()` already guards against out-of-range hop counts (`if (hop_count > MAX_HOPS) return false;`, see `distance_vector_routing_table.cpp` line ~77), but that guard sits after any addition, so it does not protect `ProcessRoutingTableMessage()`, which never performed this check at all.

## Fix

Add a guard before the `+ 1` arithmetic that rejects any wire-supplied `entry.hop_count` that would overflow `uint8_t` on increment (`>= 255`), so the wraparound path can never be reached:

```cpp
if (entry.hop_count >= 255) {
    continue;
}
```

## Testing

Added `ProcessRoutingMessageRejectsHopCountOverflow` next to the existing `ProcessRoutingMessageRespectsMaxHops` test in `test/protocols/lora_mesh/services/test_routing_unit/routing_table_unit_test.cpp`, exercising `ProcessRoutingTableMessage()` directly with `entry.hop_count = 255` and asserting the destination is not added while the direct-neighbor source still is.

I could not run the `test_native` PlatformIO environment on this machine (it requires `clang++` + the LLVM sanitizer runtime headers, neither of which is available in the local toolchain), so I additionally verified the guard logic with a standalone program mirroring the exact expressions from the fixed code: hop counts 3, 4 (boundary), 5 (normal over-limit), and 255 (wraparound) all behave identically to before except the 255 case, which is now correctly rejected instead of admitted as a phantom 0-hop route — 0 regressions across the 4 cases.