### PR TITLE
Add Arduino IDE support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ include(FetchContent)
 FetchContent_Declare(
     radiolib
     GIT_REPOSITORY https://github.com/jgromes/RadioLib.git
-    GIT_TAG 7.1.2
+    GIT_TAG 7.6.0
 )
 FetchContent_MakeAvailable(radiolib)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ A C++20 mesh networking library for LoRa nodes, built on a TDMA-based distance-v
 
 ## Quick Start
 
+### PlatformIO (recommended)
+
 1. Install [Visual Studio Code](https://code.visualstudio.com/) and the [PlatformIO extension](https://platformio.org/install/ide?install=vscode).
 2. Clone this repository.
 3. Open PlatformIO Home → **Projects** → **Add Existing** → pick the example below that matches your use case.
@@ -80,6 +82,21 @@ A C++20 mesh networking library for LoRa nodes, built on a TDMA-based distance-v
 | `examples/simple_example` | First time with the library — minimal Builder + callback flow |
 | `examples/queued_receive_example` | RX should be handled in a separate FreeRTOS task instead of inside the callback |
 | `examples/battery_optimized_example` | Battery-powered nodes that sleep between TDMA slots |
+
+### Arduino IDE
+
+LoRaMesher is an **ESP32-only** library and requires a **C++20** toolchain.
+
+1. Install the **ESP32 Arduino core 3.x or newer** via Boards Manager. Core 3.x
+   compiles at C++20 by default; **core 2.x compiles at C++11 and will not
+   build this library** (the Arduino IDE has no per-library way to raise the C++
+   standard).
+2. Install the library: either download this repository as a ZIP and use
+   **Sketch → Include Library → Add .ZIP Library…**, or (once it is listed)
+   install **LoRaMesher** from **Tools → Manage Libraries…**.
+3. Install the **RadioLib** dependency from **Tools → Manage Libraries…**.
+4. Open **File → Examples → LoRaMesher → SimpleMesh**, select your ESP32 board,
+   and upload.
 
 ---
 

--- a/examples/SimpleMesh/SimpleMesh.ino
+++ b/examples/SimpleMesh/SimpleMesh.ino
@@ -1,0 +1,237 @@
+/**
+ * @file SimpleMesh.ino
+ * @brief Simple example demonstrating LoRaMesher mesh networking on the ESP32
+ *
+ * This sketch shows how to set up a LoRa mesh network node that:
+ * - Auto-discovers and joins existing networks
+ * - Sends periodic "Hello" messages to peers
+ * - Prints the routing table and network status over Serial
+ *
+ * Requires the ESP32 Arduino core 3.x or newer (C++20). Install the RadioLib
+ * dependency from the Library Manager before compiling.
+ */
+
+#include "loramesher.hpp"
+
+using namespace loramesher;
+
+// =============================================================================
+// Hardware Pin Configuration
+// =============================================================================
+// Configure these pins for your board. Common configurations:
+//   TTGO T-Beam v1.x:    CS=18, RST=23, IRQ=26, IO1=33  (SX1276)
+//   TTGO LoRa32 v1:      CS=18, RST=14, IRQ=26, IO1=33  (SX1278)
+//   LILYGO T3 S3 v1.x:   CS=7,  RST=8,  IRQ=9,  IO1=33  (SX1278)
+//   Heltec WiFi LoRa:    CS=18, RST=14, IRQ=26, IO1=35  (SX1276)
+//   Heltec WiFi LoRa V3: CS=8,  RST=12, IRQ=14, IO1=13  (SX1262)
+//     SPI pins: SCK=9, MISO=11, MOSI=10
+//     Requires: radioConfig.setTcxoVoltage(1.8F)
+
+#define LORA_CS 18   // SPI Chip Select (NSS)
+#define LORA_RST 23  // Radio Reset pin
+#define LORA_IRQ 26  // DIO0 - Primary interrupt
+#define LORA_IO1 33  // DIO1 - Secondary interrupt
+
+// =============================================================================
+// Radio Configuration
+// =============================================================================
+// Frequency: Use appropriate band for your region (EU868, US915, etc.)
+// SF7 + 125kHz: Good balance of range and speed
+// Power: Start low (6 dBm) for testing, increase for longer range
+
+#define LORA_RADIO_TYPE RadioType::kSx1276
+#define LORA_FREQUENCY 869.900F   // MHz - EU868 band
+#define LORA_SPREADING_FACTOR 7U  // SF7-SF12: higher = more range, slower
+#define LORA_BANDWITH 125.0       // kHz - 125/250/500
+#define LORA_CODING_RATE 7U       // 5-8: higher = more error correction
+#define LORA_POWER 6              // dBm - transmit power
+#define LORA_SYNC_WORD 20U        // Network identifier (0-255)
+#define LORA_CRC true             // Enable CRC checking
+#define LORA_PREAMBLE_LENGTH 8U   // Preamble symbols
+
+// =============================================================================
+// Global Variables
+// =============================================================================
+
+std::unique_ptr<LoraMesher> mesher = nullptr;
+uint8_t counter_address = 0;  // Cycles through routing table destinations
+
+// =============================================================================
+// Callbacks
+// =============================================================================
+
+/**
+ * @brief Called when data is received from another node
+ *
+ * This callback runs in the protocol context. For production code,
+ * forward data to a separate task for processing to avoid blocking.
+ *
+ * @param source Address of the sending node
+ * @param data   Received payload bytes
+ */
+void OnDataReceived(AddressType source, const std::vector<uint8_t>& data) {
+    Serial.printf("Received data from: 0x%04X (%u bytes)\n",
+                  static_cast<unsigned>(source),
+                  static_cast<unsigned>(data.size()));
+
+    for (size_t i = 0; i < data.size(); ++i) {
+        Serial.printf("%02X ", data[i]);
+    }
+    Serial.println(data.empty() ? "(no data)" : "");
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/** @brief Prints all entries in the routing table */
+void printRoutingTable() {
+    auto routes = mesher->GetRoutingTable();
+    Serial.printf("Routing table has %u entries:\n",
+                  static_cast<unsigned>(routes.size()));
+    for (const auto& route : routes) {
+        Serial.printf("  Destination: 0x%04X, Next hop: 0x%04X, Hops: %d, Valid: %s\n",
+                      static_cast<unsigned>(route.destination),
+                      static_cast<unsigned>(route.next_hop),
+                      static_cast<int>(route.hop_count),
+                      route.is_valid ? "yes" : "no");
+    }
+}
+
+/** @brief Prints network synchronization status */
+void printNetworkStatus() {
+    auto status = mesher->GetNetworkStatus();
+    Serial.printf("Network status: State=%d, Manager=0x%04X, Slot=%u, Nodes=%u\n",
+                  static_cast<int>(status.current_state),
+                  static_cast<unsigned>(status.network_manager),
+                  static_cast<unsigned>(status.current_slot),
+                  static_cast<unsigned>(status.connected_nodes));
+
+    if (status.is_synchronized) {
+        Serial.printf("Node is synchronized, last sync %u ms ago.\n",
+                      static_cast<unsigned>(status.time_since_last_sync_ms));
+    } else {
+        Serial.println("Node is not synchronized.");
+    }
+}
+
+/**
+ * @brief Sends a test message to the next peer in the routing table
+ * @return true if message was sent, false otherwise
+ */
+bool sendTestMessage() {
+    auto routes = mesher->GetRoutingTable();
+    if (routes.empty()) {
+        return false;
+    }
+
+    AddressType dest = routes[counter_address % routes.size()].destination;
+
+    if (dest == mesher->GetNodeAddress()) {
+        counter_address++;
+        return false;
+    }
+
+    Result ready = mesher->IsReadyToSend(dest);
+    if (!ready) {
+        Serial.printf("Not ready to send to 0x%04X: %s\n",
+                      static_cast<unsigned>(dest),
+                      ready.GetErrorMessage().c_str());
+        return false;
+    }
+
+    std::string message = "Hello from node!";
+    Result result = mesher->Send(
+        dest, std::vector<uint8_t>(message.begin(), message.end()));
+
+    if (result) {
+        Serial.printf("Sent message to 0x%04X\n", static_cast<unsigned>(dest));
+        counter_address++;
+        return true;
+    }
+
+    Serial.printf("Failed to send message: %s\n",
+                  result.GetErrorMessage().c_str());
+    return false;
+}
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+void ConfigureAndUseLoraMesher() {
+    // Step 1: Configure hardware pins
+    PinConfig pinConfig(LORA_CS, LORA_RST, LORA_IRQ, LORA_IO1);
+
+    // Step 2: Configure radio parameters
+    RadioConfig radioConfig(LORA_RADIO_TYPE, LORA_FREQUENCY,
+                            LORA_SPREADING_FACTOR, LORA_BANDWITH,
+                            LORA_CODING_RATE, LORA_POWER, LORA_SYNC_WORD,
+                            LORA_CRC, LORA_PREAMBLE_LENGTH);
+
+    // --- Heltec WiFi LoRa V3 configuration ---
+    // PinConfig pinConfig(8, 12, 14, 13, 9, 11, 10);  // CS, RST, IRQ, IO1, SCK, MISO, MOSI
+    // RadioConfig radioConfig(RadioType::kSx1262, 868.0F, 7U, 125.0, 7U, 14, 20U, true, 8U);
+    // radioConfig.setTcxoVoltage(1.8F);
+
+    // Step 3: Create protocol configuration (uses defaults)
+    LoRaMeshProtocolConfig mesh_config;
+
+    // Step 4: Build and configure LoraMesher instance
+    mesher = LoraMesher::Builder()
+                 .withRadioConfig(radioConfig)
+                 .withPinConfig(pinConfig)
+                 .withLoRaMeshProtocol(mesh_config)
+                 .Build();
+
+    // Step 5: Register data callback
+    mesher->SetDataCallback(OnDataReceived);
+
+    // Step 6: Start the mesh network
+    Result init_result = mesher->Start();
+    if (!init_result) {
+        Serial.printf("Failed to start LoraMesher: %s\n",
+                      init_result.GetErrorMessage().c_str());
+        return;
+    }
+
+    // Step 7: Set up route update notifications (optional)
+    auto mesh_protocol = mesher->GetLoRaMeshProtocol();
+    if (mesh_protocol) {
+        mesh_protocol->SetRouteUpdateCallback(
+            [](bool route_updated, AddressType destination,
+               AddressType next_hop, uint8_t hop_count) {
+                if (route_updated) {
+                    Serial.printf(
+                        "Route updated - Destination: 0x%04X, Next hop: 0x%04X, Hops: %d\n",
+                        static_cast<unsigned>(destination),
+                        static_cast<unsigned>(next_hop),
+                        static_cast<int>(hop_count));
+                } else {
+                    Serial.printf("Route removed for destination: 0x%04X\n",
+                                  static_cast<unsigned>(destination));
+                }
+            });
+    }
+}
+
+// =============================================================================
+// Arduino Entry Points
+// =============================================================================
+
+void setup() {
+    Serial.begin(115200);
+    ConfigureAndUseLoraMesher();
+}
+
+void loop() {
+    printRoutingTable();
+    printNetworkStatus();
+
+    bool sent = sendTestMessage();
+    auto routes = mesher->GetRoutingTable();
+
+    // Wait before next iteration.
+    // Longer delay when there are more routes to avoid congestion.
+    delay(sent ? 10000 * routes.size() : 10000);
+}

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -5,4 +5,4 @@ dependencies:
   RadioLib:
     public: true
     git: https://github.com/jgromes/RadioLib.git
-    version: 7.1.2
+    version: 7.6.0

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,55 @@
+#######################################
+# Syntax Coloring Map For LoRaMesher
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+LoraMesher	KEYWORD1
+Builder	KEYWORD1
+PinConfig	KEYWORD1
+RadioConfig	KEYWORD1
+LoRaMeshProtocolConfig	KEYWORD1
+PingPongProtocolConfig	KEYWORD1
+Result	KEYWORD1
+RouteEntry	KEYWORD1
+NetworkStatus	KEYWORD1
+AddressType	KEYWORD1
+RadioType	KEYWORD1
+NodeRole	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+Start	KEYWORD2
+Stop	KEYWORD2
+Send	KEYWORD2
+SendBroadcast	KEYWORD2
+SendMessage	KEYWORD2
+IsReadyToSend	KEYWORD2
+SetDataCallback	KEYWORD2
+GetRoutingTable	KEYWORD2
+GetNetworkStatus	KEYWORD2
+GetNodeAddress	KEYWORD2
+GetNodeRole	KEYWORD2
+SetNodeRole	KEYWORD2
+GetNodeCapabilities	KEYWORD2
+SetNodeCapabilities	KEYWORD2
+GetClosestGateway	KEYWORD2
+GetClosestNodeByCapability	KEYWORD2
+GetLoRaMeshProtocol	KEYWORD2
+GetPingPongProtocol	KEYWORD2
+GetSlotTable	KEYWORD2
+GetTxQueueSize	KEYWORD2
+GetRxQueueSize	KEYWORD2
+GenerateAddressFromHardware	KEYWORD2
+withRadioConfig	KEYWORD2
+withPinConfig	KEYWORD2
+withProtocolConfig	KEYWORD2
+withNodeAddress	KEYWORD2
+withNodeCapabilities	KEYWORD2
+withLoRaMeshProtocol	KEYWORD2
+withPingPongProtocol	KEYWORD2
+Build	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=A mesh network for LoRa.
 paragraph=The LoRaMesher library implements a distance-vector routing protocol for communicating messages among LoRa nodes.
 category=Communication
 url=https://github.com/LoRaMesher/LoRaMesher
-architectures=*
-includes=LoRaMesher.h
+architectures=esp32
+includes=loramesher.hpp
 depends=RadioLib (>=7.1.2)


### PR DESCRIPTION
## Description

Makes LoRaMesher installable and usable directly from the Arduino IDE (ESP32).
The mesh code itself already compiles under the IDE — platform detection keys off
the `ARDUINO` macro, native/mock/test code is guarded out by
`LORAMESHER_BUILD_NATIVE`, and FreeRTOS is supplied by the ESP32 core — so the
gaps were packaging, examples, and docs:

- **`library.properties`**: `includes=LoRaMesher.h` pointed at a file that does
  not exist — fixed to the real entry header `loramesher.hpp`. `architectures=*`
  narrowed to `esp32` (the only supported platform).
- **`examples/SimpleMesh/SimpleMesh.ino`**: a proper Arduino sketch so the
  library shows up under *File → Examples → LoRaMesher* (the existing examples
  are PlatformIO `.cpp` projects and are invisible to the IDE). Uses `Serial`
  output and the same Builder API as `examples/simple_example`.
- **`keywords.txt`**: editor syntax highlighting for the public API.
- **RadioLib pin alignment**: `CMakeLists.txt` and `idf_component.yml` bumped
  from `7.1.2` to `7.6.0` to match the version PlatformIO/CI already builds and
  tests against.
- **README**: new *Arduino IDE* section documenting install steps and the
  **ESP32 Arduino core 3.x (C++20)** requirement — core 2.x compiles at C++11
  and cannot build this library, and the Arduino IDE has no per-library way to
  raise the C++ standard.

No changes to `src/` — the conditional-compilation split already works under the
Arduino IDE.

## Related Issue
<!--- N/A -->

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing Description

No library source changed, so the existing PlatformIO ESP32 and native builds
are unaffected by construction. The Arduino-IDE path is verified by compiling the
new `SimpleMesh` example in the Arduino IDE against an ESP32 core 3.x board
(manual step — requires the IDE + ESP32 core).

## Checklist:
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have verified my changes in a real device

---
_Generated by [Claude Code](https://claude.ai/code/session_0158v9K9TmJYanymMVk1ViQx)_