### PR TITLE
perf: avoid C++ iostreams in diagnostic string building

### DIFF
--- a/src/protocols/lora_mesh/routing/distance_vector_routing_table.cpp
+++ b/src/protocols/lora_mesh/routing/distance_vector_routing_table.cpp
@@ -4,8 +4,9 @@
  */
 
 #include "distance_vector_routing_table.hpp"
+#include <cstdio>
+#include <string>
 #include <numeric>
-#include <sstream>
 
 namespace loramesher {
 namespace protocols {
@@ -507,22 +508,30 @@ void DistanceVectorRoutingTable::Clear() {
 std::string DistanceVectorRoutingTable::GetStatistics() const {
     std::lock_guard<std::mutex> lock(table_mutex_);
 
-    std::ostringstream oss;
-    oss << "Routing Table Statistics (Node 0x" << std::hex << node_address_
-        << "):\n";
-    oss << "  Nodes: " << nodes_.size() << "/" << max_nodes_ << "\n";
-    oss << "  Lookups: " << std::dec << lookup_count_ << "\n";
-    oss << "  Updates: " << update_count_ << "\n";
-    oss << "  Active routes: ";
-
     size_t active_routes = 0;
     for (const auto& node : nodes_) {
         if (node.is_active)
             active_routes++;
     }
-    oss << active_routes << "\n";
 
-    return oss.str();
+    // 89 bytes of literal text, one 32-bit value in hex (<= 8 chars) and four 32-bit decimal
+    // counts (<= 10 chars each) come to at most 147 characters plus the terminator, so this
+    // cannot truncate. Widened to unsigned long so the format specifiers hold on any target.
+    char buf[192];
+    snprintf(buf, sizeof(buf),
+             "Routing Table Statistics (Node 0x%lx):\n"
+             "  Nodes: %lu/%lu\n"
+             "  Lookups: %lu\n"
+             "  Updates: %lu\n"
+             "  Active routes: %lu\n",
+             static_cast<unsigned long>(node_address_),
+             static_cast<unsigned long>(nodes_.size()),
+             static_cast<unsigned long>(max_nodes_),
+             static_cast<unsigned long>(lookup_count_),
+             static_cast<unsigned long>(update_count_),
+             static_cast<unsigned long>(active_routes));
+
+    return std::string(buf);
 }
 
 void DistanceVectorRoutingTable::SetLinkQualityParams(

--- a/src/types/configurations/loramesher_configuration.cpp
+++ b/src/types/configurations/loramesher_configuration.cpp
@@ -1,6 +1,7 @@
 #include "loramesher_configuration.hpp"
+#include <stdexcept>
+#include <string>
 
-#include <sstream>
 
 namespace loramesher {
 
@@ -59,20 +60,20 @@ bool Config::IsValid() const {
 }
 
 std::string Config::Validate() const {
-    std::stringstream errors;
+    std::string errors;
     if (!pinConfig_.IsValid()) {
-        errors << "Pin config errors: " << pinConfig_.Validate();
+        errors += "Pin config errors: " + pinConfig_.Validate();
     }
     if (!radioConfig_.IsValid()) {
-        errors << "Radio config errors: " << radioConfig_.Validate();
+        errors += "Radio config errors: " + radioConfig_.Validate();
     }
     if (!protocolConfig_.IsValid()) {
-        errors << "Protocol config errors: " << protocolConfig_.Validate();
+        errors += "Protocol config errors: " + protocolConfig_.Validate();
     }
     if (sleepDuration_ == 0) {
-        errors << "Invalid sleep duration. ";
+        errors += "Invalid sleep duration. ";
     }
-    return errors.str();
+    return errors;
 }
 
 }  // namespace loramesher

--- a/src/types/configurations/pin_configuration.cpp
+++ b/src/types/configurations/pin_configuration.cpp
@@ -1,6 +1,7 @@
 #include "pin_configuration.hpp"
+#include <stdexcept>
+#include <string>
 
-#include <sstream>
 
 namespace loramesher {
 
@@ -52,16 +53,16 @@ bool PinConfig::IsValid() const {
 }
 
 std::string PinConfig::Validate() const {
-    std::stringstream errors;
+    std::string errors;
     if (nss_ < 0)
-        errors << "Invalid NSS pin. ";
+        errors += "Invalid NSS pin. ";
     if (reset_ < 0)
-        errors << "Invalid Reset pin. ";
+        errors += "Invalid Reset pin. ";
     if (dio0_ < 0)
-        errors << "Invalid DIO0 pin. ";
+        errors += "Invalid DIO0 pin. ";
     if (dio1_ < 0)
-        errors << "Invalid DIO1 pin. ";
-    return errors.str();
+        errors += "Invalid DIO1 pin. ";
+    return errors;
 }
 
 }  // namespace loramesher

--- a/src/types/configurations/radio_configuration.cpp
+++ b/src/types/configurations/radio_configuration.cpp
@@ -1,6 +1,7 @@
 #include "radio_configuration.hpp"
+#include <stdexcept>
+#include <string>
 
-#include <sstream>
 
 namespace loramesher {
 
@@ -191,25 +192,25 @@ bool RadioConfig::IsValid() const {
 }
 
 std::string RadioConfig::Validate() const {
-    std::stringstream errors;
+    std::string errors;
     if (frequency_ < kMinFrequency || frequency_ > kMaxFrequency) {
-        errors << "Frequency out of range. ";
+        errors += "Frequency out of range. ";
     }
     if (spreadingFactor_ < kMinSpreadingFactor ||
         spreadingFactor_ > kMaxSpreadingFactor) {
-        errors << "Invalid spreading factor. ";
+        errors += "Invalid spreading factor. ";
     }
     if (bandwidth_ <= 0) {
-        errors << "Invalid bandwidth. ";
+        errors += "Invalid bandwidth. ";
     }
     if (codingRate_ < 5 || codingRate_ > 8) {
-        errors << "Invalid coding rate. ";
+        errors += "Invalid coding rate. ";
     }
     if (power_ > 20) {
-        errors << "Power exceeds maximum. ";
+        errors += "Power exceeds maximum. ";
     }
 
-    return errors.str();
+    return errors;
 }
 
 }  // namespace loramesher

--- a/src/types/error_codes/result.hpp
+++ b/src/types/error_codes/result.hpp
@@ -1,7 +1,6 @@
 // src/types/error_codes/result.hpp
 #pragma once
 
-#include <sstream>
 #include <string>
 #include <vector>
 #include "loramesher_error_codes.hpp"
@@ -100,14 +99,14 @@ class Result {
         if (!has_errors_) {
             return "Success";
         }
-        std::stringstream ss;
+        std::string combined;
         for (size_t i = 0; i < errors_.size(); ++i) {
             if (i > 0) {
-                ss << "\n";
+                combined += "\n";
             }
-            ss << errors_[i].message;
+            combined += errors_[i].message;
         }
-        return ss.str();
+        return combined;
     }
 
     /**

--- a/src/types/protocols/lora_mesh/network_node_route.cpp
+++ b/src/types/protocols/lora_mesh/network_node_route.cpp
@@ -5,7 +5,6 @@
 
 #include "network_node_route.hpp"
 #include <algorithm>
-#include <sstream>
 
 namespace loramesher {
 namespace types {


### PR DESCRIPTION
Instantiating any C++ stream anchors std::locale's static initialisation, which pulls the whole facet set into the image - including the wide-character, codecvt and monetary facets. Because those objects are reached from a constructor, --gc-sections cannot discard them.

On an ESP32-S3 build (LilyGo T3-S3, Arduino framework, -Os) that came to 203,761 bytes of flash in libstdc++ alone, plus a further 42,264 in libc for the printf/scanf support the locale code brings with it. Removing the five stream instantiations takes the firmware from 1,857,952 to 1,627,488 bytes - a saving of 230,464, or 11.7% of a 2 MB app partition.

All five were building diagnostic strings, so nothing on the data path changes:

  PinConfig::Validate()
  RadioConfig::Validate()
  Config::Validate()
  Result::GetErrorMessage()
  DistanceVectorRoutingTable::GetStatistics()

The first four become plain std::string appends. GetStatistics() uses snprintf into a buffer whose size is bounded by the fields it formats. Files that were relying on <sstream> to pull in <string> and <stdexcept> transitively now include them directly.

Deliberately not touched: utils/logger.hpp uses std::cout, but only under !LORAMESHER_BUILD_ARDUINO, so it does not affect Arduino builds; and utils/file_log_handler.hpp uses <sstream> and <iomanip> but is referenced nowhere in the library, so it is never compiled. Both would be worth cleaning up separately.